### PR TITLE
新規登録のユーザー名のバリデーション追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
-  # デバイス
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :username ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :username ])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,11 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :username,
+            presence: true,                                    # 必須入力
+            uniqueness: true,                                  # 重複禁止
+            format: { with: /\A[a-zA-Z0-9_.~-]+\z/,
+            message: I18n.t("activerecord.attributes.user.username_format") }, # 文字種制限
+            length: { minimum: 3, maximum: 20 }               # 文字数制限
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,7 +5,7 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :username %><br />
+    <%= f.label :username, "ユーザー名（半角英数字および記号(._-~)）" %><br />
     <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
   </div>
 


### PR DESCRIPTION
 app/models/user.rb
 ```
 validates :username,
            presence: true,                                    # 必須入力
            uniqueness: true,                                  # 重複禁止
            format: { with: /\A[a-zA-Z0-9_.~-]+\z/,
            message: I18n.t('users.nickname_format') }, # 文字種制限
            length: { minimum: 3, maximum: 20 }               # 文字数制限
```
