### PR TITLE
投稿一覧

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [ :index ]
   def index
+    @posts = Post.includes(:user)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,8 @@
+class Post < ApplicationRecord
+  validates :region, presence: true, length: { maximum: 50 }
+  validates :shop_name, presence: true, length: { maximum: 50 }
+  validates :rating, presence: true, inclusion: { in: 1..5 }
+  validates :body, length: { maximum: 500 }
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,5 @@ class User < ApplicationRecord
             format: { with: /\A[a-zA-Z0-9_.~-]+\z/,
             message: I18n.t("activerecord.attributes.user.username_format") }, # 文字種制限
             length: { minimum: 3, maximum: 20 }               # 文字数制限
+  has_many :posts, dependent: :destroy
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,22 +1,46 @@
 <html data-theme="retro"></html>
-<h1>Posts#index</h1>
-<p>Find me in app/views/posts/index.html.erb</p>
-<h1 class="text-4xl text-primary font-semibold underline">Hello,world</h1>
-<button class="btn btn-neutral">Hello daisyUI!</button>
-<button class="btn btn-accent">Hello daisyUI!</button>
+<div class="container mx-auto px-4 py-6">
+  <h1 class="text-2xl font-bold mb-6">投稿一覧</h1>
+  
+  <!-- 投稿カードグリッド -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5 px-2">
+    <% @posts.each do |post| %>
+      <div class="card bg-neutral shadow-sm w-72 mx-auto h-96">
+        <div class="card-body p-6 flex flex-col h-full">
+          <!-- ユーザー情報 -->
+          <div class="flex items-center gap-2 text-xs">
+            <div class="avatar">
+              <div class="w-6 rounded-full">
+                <div class="bg-secondary w-6 h-6 rounded-full"></div>
+              </div>
+            </div>
+            <%= post.user.username %>
+            <span class="text-accent/70"><%= post.created_at.strftime("%Y/%m/%d %H:%M") %></span>
+            <div class="badge badge-secondary text-accent badge-sm rounded-2xl">PR</div>
+          </div>
+          
+          <!-- 地域・店名 -->
+          <div class="flex items-center gap-2 mt-2 h-8">
+            <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt"><polyline points="1 11 12 2 23 11" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"></polyline><path d="m5,13v7c0,1.105.895,2,2,2h10c1.105,0,2-.895,2-2v-7" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path><line x1="12" y1="22" x2="12" y2="18" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></line></g></svg>
+            <span class="text-sm whitespace-nowrap "><%= post.region %></span>
+            <span class="font-medium whitespace-nowrap overflow-hidden"><%= post.shop_name %></span>
+          </div>
+          
+          <!-- 画像エリア -->
+          <div class="bg-gray-200 aspect-square w-full rounded mt-2 "></div>
+          
+          <!-- 評価 -->
+          <div class="rating rating-sm mt-0.5">
+            <% (1..5).each do |i| %>
+              <input type="radio" class="mask mask-star-2 bg-primary " 
+                     disabled <%= 'checked' if i <= post.rating %> />
+            <% end %>
+          </div>
 
-<div class="navbar bg-secondary shadow-sm">
-  <div class="flex-none">
-    <button class="btn btn-square btn-ghost">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block h-5 w-5 stroke-current"> <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path> </svg>
-    </button>
-  </div>
-  <div class="flex-1">
-    <a class="btn btn-ghost text-xl">daisyUI</a>
-  </div>
-  <div class="flex-none">
-    <button class="btn btn-square btn-ghost">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block h-5 w-5 stroke-current"> <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"></path> </svg>
-    </button>
+          <!-- 他の人の投稿はブックマークアイコン -->
+          <!-- 自分の投稿は編集アイコン、削除アイコン -->
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,3 @@
 <%# devise フラッシュメッセージ %>
 <p class="notice"><%= notice %></p>
-<p class="alert"><%= alert %></p>
+<p class="alert bg-secondary"><%= alert %></p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,15 +16,14 @@
           <li><a>マイページ</a></li>
           <li><%= link_to "ログアウト", destroy_user_session_path, data: { "turbo-method": :delete } %></li>
           <li><a>新規投稿</a></li>
-          <li><a>投稿一覧</a></li>
         <% else %>
           <!-- 未ログイン時のメニュー -->
 
           <li><%= link_to "ログイン", new_user_session_path %></li>
           <li><%= link_to "新規登録", new_user_registration_path %></li>
-          <li><a>投稿一覧</a></li>
         <% end %>
           <!-- 共通メニュー -->
+          <li><%= link_to "投稿一覧", posts_path %></li>
           <li><%= link_to "アプリの使い方", root_path %></li>
           <li><a>利用規約</a></li>
           <li><a>プライバシーポリシー</a></li>

--- a/db/migrate/20250920141453_create_posts.rb
+++ b/db/migrate/20250920141453_create_posts.rb
@@ -1,0 +1,13 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :region, null: false
+      t.string :shop_name, null: false
+      t.text :body
+      t.integer :rating, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_18_133934) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_20_141453) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "region", null: false
+    t.string "shop_name", null: false
+    t.text "body"
+    t.integer "rating", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,4 +38,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_18_133934) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
+
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
postテーブルにカラムを追加
- postsテーブルを作成
  - user_id: ユーザーとの関連付け（外部キー）
  - region: 地域名（必須）
  - shop_name: 店舗名（必須）
  - body: 投稿内容
  - rating: 評価（必須、整数）
導線を追加
- 投稿一覧ページ（posts#index）を実装
- ヘッダーナビゲーションに投稿一覧への導線を追加
投稿一覧を作成