### PR TITLE
TOPページ作成、ヘッダーフッターのリンク追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :index ]
+  skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_user_post, only: [ :edit, :update, :destroy ]
   # 自分の投稿かをチェック
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -5,13 +5,17 @@
 
       <!-- 都道府県 -->
       <div class="form-control mb-4">
-        <%= f.label :region, class: "label-accent" %>
+        <%= f.label :region, class: "label-accent" do%>
+          <%= f.object.class.human_attribute_name(:region) %><span>*</span>
+        <% end %>
         <%= f.text_field :region, class: "input bg-neutral w-full", placeholder: "例: 東京都" %>
       </div>
 
       <!-- 店名 -->
       <div class="form-control mb-4">
-        <%= f.label :shop_name, class: "label-accent" %>
+        <%= f.label :shop_name, class: "label-accent" do%>
+          <%= f.object.class.human_attribute_name(:shop_name) %><span>*</span>
+        <% end %>
         <%= f.text_field :shop_name, class: "input bg-neutral w-full", placeholder: "例: スターバックス渋谷店" %>
       </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,7 +18,7 @@
           </span>
         </div>
          <!-- 自分の投稿は編集・削除アイコン -->
-         <% if current_user.own?(@post) %>
+         <% if user_signed_in? && current_user.own?(@post) %>
            <div class="flex gap-1">
              <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}" do %>
                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-pencil-icon lucide-pencil"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,15 +9,17 @@
     <span class="dock-label">検索</span>
   </button>
   
-  <button>
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-plus">
-      <circle cx="12" cy="12" r="10"/>
-      <path d="M8 12h8"/>
-      <path d="M12 8v8"/>
-    </svg>
-    <span class="dock-label">新規投稿</span>
-  </button>
-  
+  <%= link_to new_post_path, class: "dock-label" do %>
+    <div class="dock-label flex flex-col items-center justify-center">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-plus">
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M8 12h8"/>
+        <path d="M12 8v8"/>
+      </svg>
+      <%= t('.sign_up') %>
+    </div>
+  <% end %>
+
   <button>
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user-round">
       <circle cx="12" cy="8" r="5"/>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,9 @@
 <div class="navbar bg-primary shadow-sm">
   <div class="flex-1">
-    <a class="btn btn-ghost text-lg text-neutral hover:bg-secondary hover:text-primary-content">hoshi cafe</a>
+    <div class="flex-1">
+      <%= link_to "hoshi cafe", root_path,
+      class: "btn btn-ghost text-3xl text-neutral font-bold hover:bg-secondary hover:text-primary-content" %>
+    </div>
   </div>
   <div class="flex-none">
     <details class="dropdown dropdown-end">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,5 +1,12 @@
-<div class="top-wrapper">
-  <div class="top-inner-text">
-    <h1>RUNTEQ BOARD APP</h1>
-  </div>
+<div class="flex flex-col items-center text-center p-6">
+  <h1 class="text-6xl sm:text-7xl lg:text-8xl font-bold text-accent pt-10">hoshi cafe</h1>
+  <p class="text-xl pt-6">もう、映えだけで選ばない<br>
+                          本音で探す素敵なカフェ
+  </p>
+  <div class="pt-8 flex justify-between space-x-10 items-center">
+  <%= link_to "カフェを探す", posts_path,
+      class: "btn btn-primary btn-base sm:btn-lg text-neutral" %>
+  <%= link_to "ログインする", new_user_session_path,
+      class: "btn btn-primary btn-base sm:btn-lg text-neutral" %>
+</div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,8 @@ ja:
       new_post: "新規投稿"
       posts_index: "投稿一覧"
       my_page: "マイページ"
+    footer:
+      sign_up: "新規登録"
 
   defaults:
     create: "作成"


### PR DESCRIPTION
-TOPページUIを作成
-ヘッダーにTOPページへの導線を追加
-ログインしてなくても投稿詳細も見れるようにする
posts_controllerにshowを追加
```ruby
class PostsController < ApplicationController
  skip_before_action :authenticate_user!, only: [ :index, :show ]
```
-フッターの新規投稿への導線を追加
-新規投稿入力の時に必須の場所に＊を追加