### PR TITLE
MVPリリース不要のパスワードリセットをコメントアウト

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -7,10 +7,10 @@
   class: "link hover:link-accent" %><br />
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t('.forgot_your_password'), new_password_path(resource_name),
+<%#- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%#= link_to t('.forgot_your_password'), new_password_path(resource_name),
   class: "link hover:link-accent" %><br />
-<% end %>
+<%# end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />


### PR DESCRIPTION
パスワードリセットはMVPには不要のため
devise/shared/_link.htmlのパスワードリセットリンクをコメントアウト
```ruby
<%#- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
  <%#= link_to t('.forgot_your_password'), new_password_path(resource_name),
  class: "link hover:link-accent" %><br />
<%# end %>
```