### PR TITLE
Google Places API連携のためshopsテーブルを追加し、postsと紐付け

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,5 @@ class Post < ApplicationRecord
   validates :body, length: { maximum: 500 }
 
   belongs_to :user
+  belongs_to :shop, optional: true   # shop_idは任意
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,0 +1,7 @@
+class Shop < ApplicationRecord
+  validates :place_id, presence: true, uniqueness: true
+  validates :name, presence: true
+
+  has_many :posts, dependent: :nullify
+  # shopが消されたら、nullにする
+end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -7,10 +7,10 @@
   class: "link hover:link-accent" %><br />
 <% end %>
 
-<%#- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%#= link_to t('.forgot_your_password'), new_password_path(resource_name),
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to t('.forgot_your_password'), new_password_path(resource_name),
   class: "link hover:link-accent" %><br />
-<%# end %>
+<% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />

--- a/db/migrate/20251016082105_create_shops.rb
+++ b/db/migrate/20251016082105_create_shops.rb
@@ -1,0 +1,16 @@
+class CreateShops < ActiveRecord::Migration[7.2]
+  def change
+    create_table :shops do |t|
+      t.string :place_id, null: false #Google Place APIのID #API成功時は必ずnullにならない
+      t.string :name, null: false #店名
+      t.string :address # 住所
+      t.string :google_map_url # マップリンク
+      t.text :business_hours #営業時間
+      t.string :phone_number #電話
+
+      t.timestamps
+    end
+    # このテーブルの同じplaice_idは保存されない（同じ店舗が検索されたら前保存したものを使う）
+    add_index :shops, :place_id, unique: true
+  end
+end

--- a/db/migrate/20251016090711_add_shop_to_posts.rb
+++ b/db/migrate/20251016090711_add_shop_to_posts.rb
@@ -1,0 +1,6 @@
+class AddShopToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :posts, :shop, null: true, foreign_key: true
+    # shop_idはAPIで見つからない場合があるのでnull: trueに修正
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_20_141453) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_16_090711) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,7 +22,21 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_20_141453) do
     t.integer "rating", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "shop_id"
+    t.index ["shop_id"], name: "index_posts_on_shop_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "shops", force: :cascade do |t|
+    t.string "place_id", null: false
+    t.string "name", null: false
+    t.string "address"
+    t.string "google_map_url"
+    t.text "business_hours"
+    t.string "phone_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["place_id"], name: "index_shops_on_place_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -39,5 +53,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_20_141453) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "posts", "shops"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
- Google Places APIから取得した店舗情報を保存するshopsテーブルを作成
- postsテーブルにshop_idを追加（null許容）
- ShopとPostのアソシエーションとバリデーションを設定