### PR TITLE
fix: Turbo環境でのJavaScriptイベント付与の問題を解決

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -35,7 +35,9 @@ class ShopsController < ApplicationController
             }
         end
 
-        render json: { places: results, found: true }
+        render json: { places: results, found: true },
+               headers: { 'Cache-Control' => 'no-cache, no-store, must-revalidate' }
+               # キャッシュを無効化することで新しいデータが取得される
     else
         # 検索結果が見つからなかった場合
         render json: {places: [], found: false, search_query: query }

--- a/app/javascript/shop_search.js
+++ b/app/javascript/shop_search.js
@@ -1,5 +1,7 @@
-document.addEventListener("DOMContentLoaded", () => {
-    // ページが完全に読み込まれてから実行
+console.log('shop_search.js loaded');  // この行をshop_search.jsに追加
+document.addEventListener("turbo:load", () => {
+    // 最初のページ読み込み時と、Turbo Driveによる画面遷移のたびに発火
+    // DOMContentLoaded ではなく、turbo:load を使う
     const regionInput = document.getElementById("post_region");
     const shopNameInput = document.getElementById("post_shop_name");
     const button = document.getElementById("search_shop_btn");
@@ -19,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         //地域も店名も入力されているか
         if (!region || !shopName) {
-            resultDiv.innerHTML = `<div class="alert alert-error"><span>都道府県と店舗名の両方を入力してください。</span></div>`;
+            resultDiv.innerHTML = `<div class="alert bg-error/50 text-neutral"><span>都道府県と店舗名の両方を入力してください。</span></div>`;
             return;
         }
 
@@ -30,7 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
         resultDiv.innerHTML = `<div class="flex items-center gap-2"><span class="loading loading-spinner loading-md"></span> 検索中...</div>`;
 
         try {
-            const response = await fetch(`/shops/search_place?query=${encodeURIComponent(query)}`);
+            const response = await fetch(`/shops/search_place?query=${encodeURIComponent(query)}&t=${Date.now()}`);
             // ↑ GET /shops/search_place?query=京都%20スターバックス京都駅店
             const data = await response.json();
             // ↑ レスポンスをJSONに変換
@@ -38,7 +40,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (data.error) {
                 //APIエラー
-                resultDiv.innerHTML = `<div class="alert alert-error"><span>${data.error}</span></div>`;
+                resultDiv.innerHTML = `<div class="alert bg-error/50 text-neutral"><span>${data.error}</span></div>`;
                 return;
             }
 
@@ -55,7 +57,7 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         } catch (err) {
             console.error (err); // コンソールにエラーを出力（開発者用）
-            resultDiv.innerHTML = `<div class="alert alert-error"><span>検索中にエラーが発生しました。</span></div>`;
+            resultDiv.innerHTML = `<div class="alert bg-error/50 text-neutral"><span>検索中にエラーが発生しました。</span></div>`;
         }
       });
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -30,9 +30,11 @@
       <div id="shop_result" class="mt-4"></div>
 
       <!-- 既に店舗情報が保存されている場合は表示 -->
-      <div id="existing_shop_info">
-      <%= render 'shared/shop_info', shop: @post.shop, title: @post.shop_name + 'の店舗情報' %>
-      </div>
+      <% if @post.shop.present? %>
+        <div id="existing_shop_info">
+          <%= render 'shared/shop_info', shop: @post.shop, title: @post.shop_name + 'の店舗情報' %>
+        </div>
+      <% end %>
 
       <!-- 隠しフィールド：店舗詳細情報 -->
       <%= f.hidden_field :place_id, id: "post-place-id", value: @post.shop&.place_id %>


### PR DESCRIPTION
編集画面で店舗詳細ボタンを押しても動かない問題を解決
- DOMContentLoaded を turbo:load に変更
- Turboでのページ遷移時も確実に実行される
- 編集画面での店舗詳細検索が動作するようになった

古いキャッシュが残らないように対応
- Rails側でCache-Controlヘッダーを設定
- JavaScript側でURLにタイムスタンプ(&t=)を付加
- 同じ店舗検索で古いデータが表示されないように対応

エラーの色調整