### PR TITLE
マイページ編の修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -31,5 +31,6 @@ class ProfilesController < ApplicationController
 
   def profile_params
     params.require(:user).permit(:nickname, :region, :introduction)
+    # profile_imageはwebpが上書きされてしまうので含めない
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  before_save :set_nickname_if_blank
   include ImageProcessable # 画像処理
   validates :username,
             presence: true,                                    # 必須入力
@@ -34,7 +35,15 @@ class User < ApplicationRecord
   image/heif
 ].freeze
 
-validates :profile_image, content_type: ACCEPTED_CONTENT_TYPES,
+  validates :profile_image, content_type: ACCEPTED_CONTENT_TYPES,
                   size: { less_than_or_equal_to: 10.megabytes },
                   allow_blank: true
+
+  private
+
+  def set_nickname_if_blank
+    self.nickname = username if nickname.blank?
+  end
+  # マイページ編集で名前を空にしてもusernameが設置されるようにする
+
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -59,7 +59,7 @@
     <!-- 右カラム：自己紹介 -->
   <div class="flex-1">
     <h2 class="font-semibold text-lg mb-2">自己紹介</h2>
-    <div class="text-base break-all leading-normal -mt-8">
+    <div class="text-base break-all leading-normal">
       <%= @user.introduction.presence || "自己紹介がまだありません" %>
     </div>
   </div>


### PR DESCRIPTION
マイページ編集で名前を空で更新するとエラーになる問題
-userモデルに追加
```
before_save :set_nickname_if_blank

  private

  def set_nickname_if_blank
    self.nickname = username if nickname.blank?
  end
  # マイページ編集で名前を空にしてもusernameが設置されるようにする
```

自己紹介の文字と自己紹介文が被る問題
profiles/show.htmlの -mt-8を　削除