### PR TITLE
fix: 空のusername/nicknameを修正するマイグレーション

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,7 @@ class User < ApplicationRecord
   def set_nickname_if_blank
     self.nickname = username if nickname.blank?
   end
+
   # マイページ編集で名前を空にしてもusernameが設置されるようにする
 
 end

--- a/db/migrate/20251130112229_fix_empty_usernames.rb
+++ b/db/migrate/20251130112229_fix_empty_usernames.rb
@@ -1,0 +1,13 @@
+class FixEmptyUsernames < ActiveRecord::Migration[7.2]
+  def up
+    User.find_each do |user|
+      updates = {}
+      updates[:username] = "user_#{user.id}" if user.username.blank?
+      updates[:nickname] = user.username || "user_#{user.id}" if user.nickname.blank?
+      user.update_columns(updates) if updates.any?
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
- マイグレーションファイルを生成*
rails g migration FixEmptyUsernames`

db/migrate/20251130112229_fix_empty_usernames.rb

```
class FixEmptyUsernames < ActiveRecord::Migration[7.2]
  def up
    User.find_each do |user|
      updates = {}
      updates[:username] = "user_#{[user.id](http://user.id/)}" if user.username.blank?
      updates[:nickname] = user.username || "user_#{[user.id](http://user.id/)}" if user.nickname.blank?
      user.update_columns(updates) if updates.any?
    end
  end

  def down
  end
end
```