### PR TITLE
improve: 投稿画像の画質を改善

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,7 +20,7 @@ class PostsController < ApplicationController
 
     begin
       # 画像を処理して更新
-      @post.image = @post.process_and_transform_image(params[:post][:image], 854) if params[:post][:image].present?
+      @post.image = @post.process_and_transform_image(params[:post][:image], 1200) if params[:post][:image].present?
 
       if @post.save
         redirect_to posts_path, notice: t("defaults.flash_message.created", item: Post.model_name.human), status: :see_other
@@ -50,7 +50,7 @@ class PostsController < ApplicationController
 
     # 画像を処理して更新
     begin
-      @post.image = @post.process_and_transform_image(params[:post][:image], 854) if params[:post][:image].present?
+      @post.image = @post.process_and_transform_image(params[:post][:image], 1200) if params[:post][:image].present?
 
       if @post.update(post_params)
         redirect_to post_path(@post), notice: t("defaults.flash_message.updated", item: Post.model_name.human), status: :see_other

--- a/app/models/concerns/image_processable.rb
+++ b/app/models/concerns/image_processable.rb
@@ -17,7 +17,7 @@ module ImageProcessable
           .resize_to_fit(width, nil) # サイズ調整
           .convert("webp")  # 形式変換
           .saver(strip: true, # メタデータ削除でプライバシー保護
-                quality: 85 # 画質
+                quality: 90 # 画質
                 )
           .call # 実行
 


### PR DESCRIPTION
-postコントローラーの
854 → 1200 に変更
@post.image = @post.process_and_transform_image(params[:post][:image], 1200) if params[:post][:image].present?
-画質を上げる`ImageProcessable` を修正
```
saver(strip: true,
       quality: 85 → 90に変更
```