### PR TITLE
improve: 投稿詳細画像を元サイズで中央表示に変更

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -70,9 +70,9 @@
       </div>
 
       <!-- 画像エリア -->
-      <div class="bg-gray-200 w-full rounded overflow-hidden mb-2">
+      <div class="flex justify-center w-full rounded overflow-hidden mb-2">
         <% if @post.image.attached? %>
-          <%= image_tag(@post.image, alt: "#{@post.shop_name}の画像", class: "w-full h-auto object-cover") %>
+          <%= image_tag(@post.image, alt: "#{@post.shop_name}の画像", class: "max-w-full h-auto object-cover") %>
         <% else %>
           <%= image_tag("coffee.jpg", alt: "デフォルト画像", class: "w-full h-auto object-cover") %>
         <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_17_115601) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_30_112229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
post/show.htmlを投稿画像の大きさに合わせるように変更
```
<!-- 画像エリア -->
      <div class="flex justify-center w-full rounded overflow-hidden mb-2">
        <% if @post.image.attached? %>
          <%= image_tag(@post.image, alt: "#{@post.shop_name}の画像", class: "max-w-full h-auto object-cover") %>
        <% else %>
          <%= image_tag("coffee.jpg", alt: "デフォルト画像", class: "w-full h-auto object-cover") %>
        <% end %>
      </div>
```