### PR TITLE
PRバッジの追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,7 @@ class PostsController < ApplicationController
   end
 
   def new
-    @post = Post.new(rating: 3)
+    @post = Post.new(rating: 3, is_pr: false)
   end
   # デフォルトで3点を設定
 
@@ -74,7 +74,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:region, :shop_name, :rating, :body, :shop_id)
+    params.require(:post).permit(:region, :shop_name, :rating, :body, :shop_id, :is_pr)
   end
   # :imageを追加(画像)
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,8 +2,9 @@ class Post < ApplicationRecord
   include ImageProcessable # 画像処理
   validates :region, presence: true, length: { maximum: 5 }
   validates :shop_name, presence: true, length: { maximum: 28 }
-  validates :rating, presence: true, inclusion: { in: 1..5 }
+  validates :rating, inclusion: { in: 1..5 }
   validates :body, length: { maximum: 500 }
+  validates :is_pr, inclusion: { in: [true, false] }
 
   belongs_to :user
   belongs_to :shop, optional: true   # shop_idは任意

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,3 +1,4 @@
+<!-- 新規投稿 -->
 <!-- 入力フォーム -->
 <%# local: true ← Turbo Drive で送信しない（通常の form 送信）%>
 <%= form_with model: @post, local: true do |f| %>
@@ -58,6 +59,16 @@
             <% end %>
            </div>
       </div>
+
+      <!-- PR -->
+      <div class="form-control mb-4">
+        <%= f.label :is_pr, class: "label-accent" do %>
+        <%= f.check_box :is_pr, class: "checkbox checkbox-sm border-primary border-2"%>
+          PR投稿の場合はチェックしてください
+        <% end %>
+      </div>
+
+
 
       <!-- 画像 -->
       <div class="form-control mb-4">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -28,7 +28,10 @@
 
       <%= link_to truncate(post.user.username, length: 12, omission: '...'), profile_path(post.user) %>
       <span class="text-accent/70"><%= post.created_at.strftime("%Y/%m/%d") %></span>
-      <div class="badge badge-secondary text-accent badge-sm rounded-2xl ml-auto">PR</div>
+      <!-- PRバッジ -->
+      <% if post.is_pr %>
+        <span class="badge badge-secondary text-accent badge-sm rounded-2xl ml-auto">PR</span>
+      <% end %>
     </div>
     
     <!-- 地域・店名 -->

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,4 @@
+<!-- 投稿一覧 -->
 <div class="container mx-auto px-4 py-6 pb-20">
   <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -45,7 +45,10 @@
              <% end %>
            </div>
          <% end %>
-        <div class="badge badge-secondary text-accent badge-base rounded-2xl">PR</div>
+         <!-- PRバッジ -->
+        <% if @post.is_pr %>
+          <span class="badge badge-secondary text-accent badge-base rounded-2xl">PR</span>
+        <% end %>
       </div>
       
       <!-- 地域・店名 -->

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,7 @@
 <div class="container mx-auto px-4 py-6 pb-20">
+    <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
 <!-- 自分のプロフィール -->
+  <div class="p-4 w-full" >
   <!-- 左右２カラムにする親 -->
   <div class="flex gap-5 mx-auto items-start">
     <!--　縦に並べる -->
@@ -59,6 +61,7 @@
     <div class="text-base break-all leading-normal">
       <%= @user.introduction.presence || "自己紹介がまだありません" %>
     </div>
+  </div>
   </div>
   </div>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,7 +11,7 @@ ja:
 
   profiles:
     show:
-      title: "マイページ"
+      title: "プロフィール"
     edit:
       title: "プロフィール編集"
       submit: "更新する"

--- a/db/migrate/20251213025243_add_is_pr_to_posts.rb
+++ b/db/migrate/20251213025243_add_is_pr_to_posts.rb
@@ -1,0 +1,5 @@
+class AddIsPrToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :is_pr, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_30_112229) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_13_025243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_30_112229) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "shop_id"
+    t.boolean "is_pr", default: false, null: false
     t.index ["shop_id"], name: "index_posts_on_shop_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end


### PR DESCRIPTION
- postsテーブルにis_prカラムを追加するマイグレーションファイルを作る
```
rails g migration AddIsPrToPosts
```
- db/migrate/20251213025243_add_is_pr_to_posts.rbに記入
```
class AddIsPrToPosts < ActiveRecord::Migration[7.2]
  def change
    add_column :posts, :is_pr, :boolean, null: false, default: false
  end
end
```
- rails db:migrate
- _form.htnl 　　　新規投稿でPR欄を追加
- posts/controllerにis_prを追加,デフォルト値を追加
- postモデルに　prのバリデーション追加
- 投稿一覧_post.htmlにPR追加
- 投稿詳細 posts.show.htmlにPR追加