### PR TITLE
お気に入り機能のajax化

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,12 +2,10 @@ class FavoritesController < ApplicationController
     def create
         @post = Post.find(params[:post_id])
         current_user.favorite(@post)
-        redirect_to posts_path, notice: t('success')
     end
 
     def destroy
         @post = current_user.favorites.find(params[:id]).post
         current_user.unfavorite(@post)
-        redirect_to posts_path, notice: t('success')
     end
 end

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%# お気に入りを押したらunfavoriteの赤ハートにUIに置き換わる %>
+<%= turbo_stream.replace "favorite-button-for-post-#{@post.id}" do %>
+  <%= render 'shared/unfavorite', post: @post %>
+<% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unfavorite-button-for-post-#{@post.id}" do %>
+  <%= render 'shared/favorite', post: @post %>
+<% end %>

--- a/app/views/shared/_favorite.html.erb
+++ b/app/views/shared/_favorite.html.erb
@@ -1,4 +1,4 @@
 <%# 空ハートをクリックしたらお気に入りにする %>
-<%= link_to favorites_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post} do %>
+<%= link_to favorites_path(post_id: post.id), id: "favorite-button-for-post-#{post.id}", data: { turbo_method: :post} do %>
   <i class="w-6 h-6 inline-block mask mask-heart bg-secondary"></i>
 <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # pfor Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).


### PR DESCRIPTION
- favorite_controllerのredirect_toを削除
```
class FavoritesController < ApplicationController
    def create
        @post = Post.find(params[:post_id])
        current_user.favorite(@post)
    end

    def destroy
        @post = current_user.favorites.find(params[:id]).post
        current_user.unfavorite(@post)
    end
end
```
- app/views/favorites/create.turbo_stream.erbを作成
```
<%# お気に入りを押したらunfavoriteの赤ハートにUIに置き換わる %>
<%= turbo_stream.replace "favorite-button-for-post-#{@post.id}" do %>
  <%= render 'shared/unfavorite', post: @post %>
<% end %>
```

- app/views/favorites/destroy.turbo_stream.erb
```
<%= turbo_stream.replace "unfavorite-button-for-post-#{@post.id}" do %>
  <%= render 'shared/favorite', post: @post %>
<% end %>
```