### PR TITLE
fix: ログアウト状態での投稿一覧表示エラーを修正

### DIFF
--- a/app/views/shared/_favorite_buttons.html.erb
+++ b/app/views/shared/_favorite_buttons.html.erb
@@ -1,4 +1,6 @@
 <!-- その掲示板をお気に入りにしているか判定 -->
+<% if user_signed_in? %>
+
 <div class='ms-auto'>
   <% if current_user.favorite?(post) %>
     <%= render 'shared/unfavorite', { post: post} %>
@@ -6,3 +8,4 @@
     <%= render 'shared/favorite', { post: post} %>
   <% end %>
 </div>
+<% end %>


### PR DESCRIPTION
_favorite_buttons.html.erbのcurrent_userがnilなのが原因
```
<!-- その掲示板をお気に入りにしているか判定 -->
<% if user_signed_in? %>

<div class='ms-auto'>
  <% if current_user.favorite?(post) %>
    <%= render 'shared/unfavorite', { post: post} %>
  <% else %>
    <%= render 'shared/favorite', { post: post} %>
  <% end %>
</div>
<% end %>
```