### PR TITLE
投稿一覧のパフォーマンス改善: AnalyzeJob無効化とN+1クエリ解決

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,7 +8,7 @@ class Post < ApplicationRecord
 
   belongs_to :user
   belongs_to :shop, optional: true   # shop_idは任意
-  has_one_attached :image # 画像投稿
+  has_one_attached :image # 画像投稿 # Rails が勝手に画像分析する必要はない
   has_one_attached :profile_image # プロフィール画像
   has_many :favorites, dependent: :destroy # お気に入り機能
 

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,3 @@
+Rails.application.config.active_storage.analyze_image_by_default = false
+# WebP変換をやってるから、Rails が勝手に画像分析する必要はない
+# メモリ不足解消


### PR DESCRIPTION
- config/initializers/active_storage.rb
```
Rails.application.config.active_storage.analyze_image_by_default = false
# WebP変換をやってるから、Rails が勝手に画像分析する必要はない
# メモリ不足解消
```
- posts_controllerの　 create とupdateに追加
```
# AnalyzeJob を無効化（メモリ節約）
        if @post.image.attached?
          @post.image.blob.update(metadata: { analyzed: true, identified: true })
        end
```
- 
```posts_controllerに.with_attached_image.order(created_at: :desc)　を追加
def index
    @posts = Post.includes(:user).with_attached_image.order(created_at: :desc)
  end
```
  画像のN+1問題解決