### PR TITLE
Revert: AnalyzeJob を標準動作に戻す

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,11 +24,6 @@ class PostsController < ApplicationController
       @post.image = @post.process_and_transform_image(params[:post][:image], 1200) if params[:post][:image].present?
 
       if @post.save
-        # AnalyzeJob を無効化（メモリ節約）
-        if @post.image.attached?
-          @post.image.blob.update(metadata: { analyzed: true, identified: true })
-        end
-
         redirect_to posts_path, notice: t("defaults.flash_message.created", item: Post.model_name.human), status: :see_other
       else
         flash.now[:alert] = t("defaults.flash_message.not_created", item: Post.model_name.human)
@@ -59,12 +54,6 @@ class PostsController < ApplicationController
       @post.image = @post.process_and_transform_image(params[:post][:image], 1200) if params[:post][:image].present?
 
       if @post.update(post_params)
-
-        # AnalyzeJob を無効化（メモリ節約）
-        if @post.image.attached?
-          @post.image.blob.update(metadata: { analyzed: true, identified: true })
-        end
-
         redirect_to post_path(@post), notice: t("defaults.flash_message.updated", item: Post.model_name.human), status: :see_other
       else
         flash.now[:alert] = t("defaults.flash_message.not_updated", item: Post.model_name.human)

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,3 +1,0 @@
-Rails.application.config.active_storage.analyze_image_by_default = false
-# WebP変換をやってるから、Rails が勝手に画像分析する必要はない
-# メモリ不足解消


### PR DESCRIPTION
AnalyzeJobを下記の理由により元に戻しました。
Rails が画像情報を正確に把握できなくなる
将来バグになる可能性
- config/initializers/active_storage.rb を削除
- PostsController の blob.update を削除
- Rails 標準の AnalyzeJob を動かす
