### PR TITLE
fix: 検索フォームの初期化と投稿カードのUI改善

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,5 @@
 class ProfilesController < ApplicationController
+
   def show
     @user = User.includes(:posts, :favorite_posts).find(params[:id])
     # 他の人のプロフィールも見れるようにする

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -22,6 +22,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }%><br />
   <% end %>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -33,16 +33,16 @@
         <span class="badge badge-secondary text-accent badge-sm rounded-2xl ml-auto">PR</span>
       <% end %>
     </div>
-    
-    <!-- 地域・店名 -->
-    <div class="flex items-center gap-2 mt-2 h-8">
-      <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt"><polyline points="1 11 12 2 23 11" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"></polyline><path d="m5,13v7c0,1.105.895,2,2,2h10c1.105,0,2-.895,2-2v-7" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path><line x1="12" y1="22" x2="12" y2="18" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></line></g></svg>
-      <span class="text-sm whitespace-nowrap"><%= truncate(post.region, length:4 , omission: '') %></span>
-      <span class="font-medium whitespace-nowrap overflow-hidden">
-        <%= link_to truncate(post.shop_name, length: 12, omission: '...'), post_path(post) %>
-      </span>
-    </div>
-    
+
+      <!-- 地域・店名 -->
+      <div class="flex items-center gap-1 mt-2 h-5  text-base">
+        <%= link_to post_path(post), class: "flex items-center gap-2 w-full hover:opacity-70 transition" do %>
+          <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt"><polyline points="1 11 12 2 23 11" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"></polyline><path d="m5,13v7c0,1.105.895,2,2,2h10c1.105,0,2-.895,2-2v-7" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2.5"></path><line x1="12" y1="22" x2="12" y2="18" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></line></g></svg>
+          <span class="whitespace-nowrap"><%= truncate(post.region, length: 4, omission: '') %></span>
+          <span class="font-bold whitespace-nowrap overflow-hidden"><%= truncate(post.shop_name, length: 12, omission: '...') %></span>
+        <% end %>
+      </div>
+
     <!-- 画像エリア -->
     <div class="bg-gray-200 aspect-square w-full rounded mt-2 overflow-hidden">
       <% if post.image.attached? %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -67,12 +67,12 @@
         <div class="flex items-center gap-2">
           <svg class="size-[1.2em] flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
-              <polyline points="1 11 12 2 23 11" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"></polyline>
+              <polyline points="1 11 12 2 23 11" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2.5"></polyline>
                <path d="m5,13v7c0,1.105.895,2,2,2h10c1.105,0,2-.895,2-2v-7" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path>
               <line x1="12" y1="22" x2="12" y2="18" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></line>
             </g>
           </svg>
-          <span class="font-medium text-lg"><%= @post.shop_name %></span>
+          <span class="font-bold text-lg"><%= @post.shop_name %></span>
         </div>
       </div>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <!-- 画面下部に固定するフッター -->
 <div class="dock dock-md bg-primary text-neutral">
   <!-- 投稿一覧 -->
-  <%= link_to posts_path do %>
+  <%= link_to posts_path, data: { turbo: false } do %>
   <div class="dock-label flex flex-col items-center justify-center">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search">
       <path d="m21 21-4.34-4.34"/>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,7 +25,7 @@
           <li><%= link_to t('.sign_up'), new_user_registration_path %></li>
         <% end %>
           <!-- 共通メニュー -->
-          <li><%= link_to t('.posts_index'), posts_path %></li>
+          <li><%= link_to t('.posts_index'), posts_path, data: { turbo: false } %></li>
           <li><%= link_to "アプリの使い方", root_path %></li>
           <li><a>利用規約</a></li>
           <li><a>プライバシーポリシー</a></li>


### PR DESCRIPTION
- _header.htmlと_footer.htmlでリンクに直接 turbo: false を追加
```
          <li><%= link_to t('.posts_index'), posts_path, data: { turbo: false } %></li>
```
- 店名の大きさ修正