### PR TITLE
TwitterカードでOGP画像を追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
-end
+    def get_twitter_card_info(post)
+      twitter_card = {}
+      
+      twitter_card[:card] = 'summary_large_image'
+      twitter_card[:url] = post_url(post)
+      twitter_card[:title] = "#{post.shop_name} - hoshi cafe"
+      twitter_card[:description] = "#{post.region}のカフェ | ★#{post.rating}"
+      
+      # 画像の有無で分岐
+      if post.image.attached?
+        twitter_card[:image] = url_for(post.image)
+      else
+        twitter_card[:image] = image_url('coffee.jpg')
+      end
+      
+      twitter_card
+    end
+  end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,16 @@
 
     <%= yield :head %>
 
+    <!-- Twitterカード / OGP -->
+    <% if @post %>
+      <% twitter_card = get_twitter_card_info(@post) %>
+      <meta name="twitter:card" content="<%= twitter_card[:card] %>" />
+      <meta property="og:url" content="<%= twitter_card[:url] %>" />
+      <meta property="og:title" content="<%= twitter_card[:title] %>" />
+      <meta property="og:description" content="<%= twitter_card[:description] %>" />
+      <meta property="og:image" content="<%= twitter_card[:image] %>" />
+    <% end %>
+
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -85,7 +85,7 @@
       <!-- 右側：Xシェアボタン -->
         <%= link_to "https://twitter.com/share?url=#{post_url(@post)}&text=【#{@post.region}のカフェ好き必見☕️】%0a hoshi cafeで#{@post.shop_name}の投稿をチェック！",
             target: '_blank', #リンクを新しいウィンドウまたはタブで開く
-            class: "btn btn-sm bg-primary text-neutral border-black" do %>
+            class: "btn btn-sm bg-primary text-neutral" do %>
               <svg aria-label="X logo" width="16" height="12" viewBox="0 0 300 271" xmlns="http://www.w3.org/2000/svg">
               <path fill="currentColor" d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z"/>
               </svg>


### PR DESCRIPTION
## 概要
投稿詳細ページのX共有機能に、Twitterカード(OGP)を実装しました。

## 変更内容
- `application_helper.rb`: Twitterカード用メタタグ情報を生成するヘルパーメソッドを追加
- `application.html.erb`: OGPメタタグを`<head>`内に追加
- `posts/show.html.erb`: Xシェアボタンを設置

## 実装詳細
- カードタイプ: `summary_large_image`
- 画像がない投稿はデフォルト画像（coffee.jpg）を使用
- 投稿詳細ページのみメタタグを出力

## TODO
- [ ] S3の公開アクセス設定（本番環境での画像表示のため）
