### PR TITLE
fix: OGP画像URLを絶対パスに修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
       
       # 画像の有無で分岐
       if post.image.attached?
-        twitter_card[:image] = url_for(post.image)
+        twitter_card[:image] = rails_blob_url(post.image)
       else
         twitter_card[:image] = image_url('coffee.jpg')
       end


### PR DESCRIPTION
app/helpers/application_helper.rbの
url_for(post.image) → rails_blob_url(post.image)を変更
することで
rails/で始まるURLから
https/から始まるURLになる