### PR TITLE
fix: OGP画像をS3直接URLに変更してリダイレクト回避

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
       
       # 画像の有無で分岐
       if post.image.attached?
-        twitter_card[:image] = rails_blob_url(post.image)
+        twitter_card[:image] = post.image.url
       else
         twitter_card[:image] = image_url('coffee.jpg')
       end


### PR DESCRIPTION
 `rails_blob_url(post.image)` → `post.image.url`
でS3の直接URLを取得