### PR TITLE
fix: OGP画像をS3直接URLに変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
 
         # 画像の有無で分岐
         if post.image.attached?
-          twitter_card[:image] = url_for(post.image)
+          twitter_card[:image] = post.image.url
         else
           twitter_card[:image] = image_url("coffee.jpg")
         end


### PR DESCRIPTION
app/helpers/application_helper.rbの
```
 # 画像の有無で分岐
        if post.image.attached?
          twitter_card[:image] = url_for(post.image)
        else
          twitter_card[:image] = image_url("coffee.jpg")
        end
```
これを
```
if post.image.attached?
  twitter_card[:image] = post.image.url
else
  twitter_card[:image] = image_url('coffee.jpg')
end
```
これに変更